### PR TITLE
Fix Python workflow triggers

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,6 +1,6 @@
 name: Python
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,6 +1,12 @@
 name: Python
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   test:


### PR DESCRIPTION
When @frepond opened PR #21, I wasn't able to figure out how to run the
Python workflow jobs which are required for merging. At first I thought
it was because I couldn't find the button to approve them. But I think
it is actually because the triggers for the job were to restrictive.