### PR TITLE
Add event loop unit test

### DIFF
--- a/pytest_motor/plugin.py
+++ b/pytest_motor/plugin.py
@@ -13,6 +13,21 @@ from _pytest.config import Config as PytestConfig
 from motor.motor_asyncio import AsyncIOMotorClient
 
 
+def _event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """Yield an event loop.
+
+    This is necessary because pytest-asyncio needs an event loop with a with an equal or higher
+    pytest fixture scope as any of the async fixtures. And remember, pytest-asynio is what allows us
+    to have async pytest fixtures.
+    """
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
+
+
+pytest.fixture(fixture_function=_event_loop, scope='session', name="event_loop")
+
+
 @pytest.fixture(scope='session')
 def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     """Yield an event loop.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,7 +1,29 @@
 """Test pytest_motor.plugin."""
+from asyncio import AbstractEventLoop
 from pathlib import Path
+from unittest.mock import Mock, patch
 
+import pytest
 from pytest import Testdir
+
+from pytest_motor.plugin import _event_loop
+
+
+def test_event_loop() -> None:
+    """Test pytest_motor.plugin._event_loop."""
+    mock_close = Mock(AbstractEventLoop.close)
+    mock_event_loop = Mock(AbstractEventLoop, close=mock_close)
+    with patch('asyncio.get_event_loop', return_value=mock_event_loop):
+        loop_iterator = _event_loop()
+
+        loop = next(loop_iterator)
+
+    assert loop is mock_event_loop
+
+    with pytest.raises(StopIteration):
+        next(loop_iterator)
+
+    mock_close.assert_called_once()
 
 
 def test_motor_client(testdir: Testdir) -> None:


### PR DESCRIPTION
Add a unit test for the event loop fixture. Unfortunately, `pytest`
does allow directly calling a fixture. This means that if we want to
directly test the behavior of a fixture, we must wrap it afterwards.
That is, use `pytest.fixture` as a function instead of as a decorator.