### PR TITLE
Fix frozen requirements files

### DIFF
--- a/requirements/frozen/frozen_coverage_requirements.txt
+++ b/requirements/frozen/frozen_coverage_requirements.txt
@@ -4,6 +4,8 @@ attrs==21.2.0
 chardet==4.0.0
 coverage==5.5
 idna==3.2
+idna-ssl==1.1.0
+importlib-metadata==4.6.1
 iniconfig==1.1.1
 motor==2.4.0
 multidict==5.1.0
@@ -18,3 +20,4 @@ pytest-cov==2.12.1
 toml==0.10.2
 typing-extensions==3.10.0.0
 yarl==1.6.3
+zipp==3.5.0

--- a/requirements/frozen/frozen_deployment_requirements.txt
+++ b/requirements/frozen/frozen_deployment_requirements.txt
@@ -1,7 +1,7 @@
 bleach==3.3.1
 certifi==2021.5.30
 cffi==1.14.6
-charset-normalizer==2.0.2
+charset-normalizer==2.0.3
 colorama==0.4.4
 cryptography==3.4.7
 docutils==0.17.1
@@ -22,6 +22,7 @@ SecretStorage==3.3.1
 six==1.16.0
 tqdm==4.61.2
 twine==3.4.1
+typing-extensions==3.10.0.0
 urllib3==1.26.6
 webencodings==0.5.1
 zipp==3.5.0

--- a/requirements/frozen/frozen_lint_requirements.txt
+++ b/requirements/frozen/frozen_lint_requirements.txt
@@ -4,6 +4,8 @@ async-timeout==3.0.1
 attrs==21.2.0
 chardet==4.0.0
 idna==3.2
+idna-ssl==1.1.0
+importlib-metadata==4.6.1
 iniconfig==1.1.1
 isort==5.9.2
 lazy-object-proxy==1.6.0
@@ -19,6 +21,8 @@ pyparsing==2.4.7
 pytest==6.2.4
 pytest-asyncio==0.15.1
 toml==0.10.2
+typed-ast==1.4.3
 typing-extensions==3.10.0.0
 wrapt==1.12.1
 yarl==1.6.3
+zipp==3.5.0

--- a/requirements/frozen/frozen_test_requirements.txt
+++ b/requirements/frozen/frozen_test_requirements.txt
@@ -3,6 +3,8 @@ async-timeout==3.0.1
 attrs==21.2.0
 chardet==4.0.0
 idna==3.2
+idna-ssl==1.1.0
+importlib-metadata==4.6.1
 iniconfig==1.1.1
 motor==2.4.0
 multidict==5.1.0
@@ -16,3 +18,4 @@ pytest-asyncio==0.15.1
 toml==0.10.2
 typing-extensions==3.10.0.0
 yarl==1.6.3
+zipp==3.5.0

--- a/requirements/frozen/frozen_type_check_requirements.txt
+++ b/requirements/frozen/frozen_type_check_requirements.txt
@@ -3,6 +3,8 @@ async-timeout==3.0.1
 attrs==21.2.0
 chardet==4.0.0
 idna==3.2
+idna-ssl==1.1.0
+importlib-metadata==4.6.1
 iniconfig==1.1.1
 motor==2.4.0
 multidict==5.1.0
@@ -16,5 +18,7 @@ pyparsing==2.4.7
 pytest==6.2.4
 pytest-asyncio==0.15.1
 toml==0.10.2
+typed-ast==1.4.3
 typing-extensions==3.10.0.0
 yarl==1.6.3
+zipp==3.5.0


### PR DESCRIPTION
Fix the frozen requirements files by running `./scripts/freeze.sh`. It
might make sense to add a GitHub Action for performing this and also
for checking the requirements files.