### PR TITLE
Add format check job

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -119,3 +119,32 @@ jobs:
     - name: Build distributions
       run: |
         ./scripts/build.sh
+
+  check-formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Cache pip packages
+      uses: actions/cache@v2
+      env:
+        cache-name: pip-packages-cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ env.cache-name }}-format-${{ hashFiles('requirements/frozen/frozen_type_check_requirements.txt') }}
+        restore-keys: |
+          ${{ env.cache-name }}-format-
+          ${{ env.cache-name }}-
+
+    - name: Format the repository
+      run: ./scripts/format.sh
+
+    - name: Check formatting
+      run: git diff --exit-code


### PR DESCRIPTION
Add a GitHub Action workflow job to check formatting of code by
running the formatting script then determining if there is a difference
with git. The reason for doing this is that we use yapf and isort and I
am not sure they are compatible which means we can't use their builtin
checking.

This isn't the only option for solving this problem but it is probably
the easiest. One other option would be to write a formatting wrapper
for other formatting tools. Another option would be to write a new
formatter...