### PR TITLE
ReadMe badges

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -35,6 +35,12 @@ jobs:
     - name: Run unit tests with pytest and check coverage
       run: ./scripts/coverage.sh
 
+    - name: Upload code coverage
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage.xml
+        flags: unittests
+
   integration-test:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 !/venvs/.gitkeep
 /dist/*
 !/dist/.gitkeep
-/.coverage
+/*coverage*
 /.mongod
 /.mongo_databases

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # pytest-motor
 
+[![PyPI version](https://img.shields.io/pypi/v/pytest-motor.svg)](https://pypi.org/project/pytest-motor/)
+[![PyPI status](https://img.shields.io/pypi/status/pytest-motor.svg)](https://pypi.python.org/pypi/pytest-motor/)
+[![codecov](https://codecov.io/gh/AustinScola/pytest-motor/branch/master/graph/badge.svg)](https://codecov.io/gh/AustinScola/pytest-motor)
+![https://github.com/AustinScola/pytest-motor/actions/workflows/python.yaml](https://github.com/AustinScola/pytest-motor/actions/workflows/python.yaml/badge.svg)
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/pytest-motor.svg)](https://pypi.python.org/pypi/pytest-motor/)
+[![Code style](https://img.shields.io/badge/code%20style-yapf-blue.svg)](https://github.com/google/yapf)
+
+
 A [pytest][1] plugin for [Motor][2], the non-blocking MongoDB driver.
 
 ## Example

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -10,4 +10,4 @@ cd "${REPO_ROOT}"
 source "${REPO_ROOT}/scripts/library/venv.sh"
 use_venv "coverage" frozen_coverage_requirements.txt
 
-python3 -m pytest -m unit --cov=pytest_motor --cov-report  term-missing
+python3 -m pytest -m unit --cov-report term-missing --cov-report xml --cov=pytest_motor

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,6 @@ setuptools.setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Framework :: Pytest',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,11 @@ setuptools.setup(
     entry_points={'pytest11': ['pytest_motor = pytest_motor.plugin']},
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Framework :: Pytest',


### PR DESCRIPTION
Add badges:

- PyPI version
- PyPI status (alpha, beta, etc.)
- Test coverage
- Current GitHub Actions status
- Supported Python versions (from PyPI)
- YAPF Code style format 

`Test coverage` badge is working with codecov, so I added codecov job to GitHub Actions.

`Supported Python versions` badge is working with PyPI, so I updated supported Python versions in PyPI.


